### PR TITLE
Use link instead repository name in Slack reporting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,8 +59,8 @@ commands:
     steps:
       - slack/status:
           include_project_field: false
-          failure_message: "Release failed for deriv-static-content with version *$(cat public/version)*"
-          success_message: "Release succeeded for deriv-static-content with version *$(cat public/version)*"
+          failure_message: "Release failed for static.deriv.com with version *$(cat public/version)*"
+          success_message: "Release succeeded for static.deriv.com with version *$(cat public/version)*"
           webhook: ${SLACK_WEBHOOK}
 
   publish_to_pages_production:


### PR DESCRIPTION
# Changes
- Use repository name instead repository name in Slack reporting

![slack-reporting-deriv-static-content](https://github.com/binary-com/deriv-static-content/assets/104425314/6c3aacfe-f82f-4beb-bad6-01c3ccfaf435)
