### PR TITLE
Ako/ pass proper environment to release production

### DIFF
--- a/.github/workflows/release_production.yml
+++ b/.github/workflows/release_production.yml
@@ -5,6 +5,7 @@ on:
       - master
 jobs:
   release_production:
+    environment: Production
     runs-on: ubuntu-latest
     container:
       image: node:18.16.1


### PR DESCRIPTION
environment key was missing in the implementation and the action couldn't find the proper secret from github. this meant to fix that issue.